### PR TITLE
Fix catkin_make error

### DIFF
--- a/cage_ros_stack/cage_ros_bridge/CMakeLists.txt
+++ b/cage_ros_stack/cage_ros_bridge/CMakeLists.txt
@@ -132,9 +132,8 @@ catkin_package(
 include_directories(
 # include
   ${catkin_INCLUDE_DIRS}
-  ${PROJECT_SOURCE_DIR}/../
-  ${PROJECT_SOURCE_DIR}/../include
-  ${PROJECT_SOURCE_DIR}/../json/include
+  ${PROJECT_SOURCE_DIR}/../../
+  ${PROJECT_SOURCE_DIR}/../../json/include
   #$ENV{WORKSPACE}/toki/furom/include
 )
 


### PR DESCRIPTION
#2 でディレクトリ変更した際にCMakeLists.txtで参照するパスが変わったのでそのままだとエラーが出ます。
そのエラーを修正するためのPRです。

```
$ catkin_make
### 中略 ###
Scanning dependencies of target cage_ros_bridge
[ 50%] Building CXX object CageClient/cage_ros_stack/cage_ros_bridge/CMakeFiles/cage_ros_bridge.dir/bridge_main.cpp.o
/home/daisuke/ros/test_ws/src/CageClient/cage_ros_stack/cage_ros_bridge/bridge_main.cpp:2:10: fatal error: cageclient.hh: No such file or directory
 #include "cageclient.hh"
          ^~~~~~~~~~~~~~~
compilation terminated.
```