### PR TITLE
json: make keys case insensitive

### DIFF
--- a/include/cageclient.hh
+++ b/include/cageclient.hh
@@ -1,11 +1,10 @@
-// Copyright 2018 Tomoaki Yoshida<yoshida@furo.org>
+// Copyright 2018-2020 Tomoaki Yoshida<yoshida@furo.org>
 /*
 This software is released under the MIT License.
 http://opensource.org/licenses/mit-license.php
 */
 
 #pragma once
-
 #include "console.hh"
 #include "subscriber.hh"
 #include <string>
@@ -164,7 +163,7 @@ bool CageAPI::connect(){
 
   Subscriber->addTargetActor(endpoint);
   Endpoint=endpoint;
-  nlohmann::json meta;
+  Json meta;
   if(!Console->getActorMetadata(endpoint, meta)){
     setError("Failed to fetch vehicle metadata");
     return false;
@@ -184,6 +183,7 @@ bool CageAPI::getStatusOne(CageAPI::vehicleStatus &vst, int timeout_us)
 {
   if(!poll(timeout_us))return false;
   auto j=Subscriber->recvOne();
+  //std::cout<<"Recv:["<<j<<"]"<<std::endl;
   if (j.find("Data") == j.end()) {
     setErrorStrm([](auto &ost) { ost << "Unexpected json structure."; });
     return false;
@@ -200,7 +200,7 @@ bool CageAPI::getStatusOne(CageAPI::vehicleStatus &vst, int timeout_us)
     vst.rrpm=static_cast<double>(r["RightRpm"]);
   auto accel=r.find("Accel");
   if(accel!=r.end()){
-    nlohmann::json a=*accel;
+    Json a=*accel;
     // cm/s^2 -> m/s^2
     vst.ax=static_cast<double>(a["X"])/100.;
     vst.ay=static_cast<double>(a["Y"])/100. * -1.;
@@ -209,14 +209,14 @@ bool CageAPI::getStatusOne(CageAPI::vehicleStatus &vst, int timeout_us)
   // [deg/s] -> [rad/s]
   auto angVel=r.find("AngVel");
   if(angVel!=r.end()){
-    nlohmann::json av=*angVel;
+    Json av=*angVel;
     vst.rx=static_cast<double>(av["X"])*M_PI/180.;
     vst.ry=static_cast<double>(av["Y"])*M_PI/180.*-1.;
     vst.rz=static_cast<double>(av["Z"])*M_PI/180.*-1.;
   }
   auto pose=r.find("Pose");
   if(pose!=r.end()){
-    nlohmann::json p=*pose;
+    Json p=*pose;
     vst.ox=static_cast<double>(p["X"]);
     vst.oy=static_cast<double>(p["Y"]) * -1.;
     vst.oz=static_cast<double>(p["Z"]);
@@ -224,8 +224,8 @@ bool CageAPI::getStatusOne(CageAPI::vehicleStatus &vst, int timeout_us)
   }
   // location  +X +Y +Z [cm]  -> +X -Y +Z [m]
   auto loc=r.find("Position");
-  if(pose!=r.end()){
-    nlohmann::json l=*loc;
+  if(loc!=r.end()){
+    Json l=*loc;
     vst.wx = static_cast<double>(l["X"])/ 100.;
     vst.wy = static_cast<double>(l["Y"])/ 100. * -1.;
     vst.wz = static_cast<double>(l["Z"])/ 100.;

--- a/include/console.hh
+++ b/include/console.hh
@@ -1,11 +1,11 @@
-// Copyright 2018 Tomoaki Yoshida<yoshida@furo.org>
+// Copyright 2018-2020 Tomoaki Yoshida<yoshida@furo.org>
 /*
 This software is released under the MIT License.
 http://opensource.org/licenses/mit-license.php
 */
-
+#pragma once
 #include "zmq_nt.hpp"
-#include <nlohmann/json.hpp>
+#include "json.hh"
 #include <sstream>
 
 #include<iostream>
@@ -23,7 +23,7 @@ public:
   bool submitRequest(std::vector<std::string> req, std::string &res);
 
   bool listEndpoints(std::string tag, std::vector<std::string> &res);
-  bool getActorMetadata(std::string actor, nlohmann::json &res);
+  bool getActorMetadata(std::string actor, Json &res);
   bool execConsoleCommand(std::string command, std::string &res);
   bool sendActorMessage(std::string endpoint, std::string command, std::string &res);
 
@@ -70,7 +70,7 @@ bool simConsole::execConsoleCommand(std::string command, std::string &res){
   if(!submitRequest(os.str(),r))
     return false;
 
-  auto rj=nlohmann::json::parse(r);
+  auto rj=Json::parse(r);
   if(rj.count("Result") || rj["Result"].is_string()){
     res=rj["Result"];
     lastErr.clear();
@@ -90,7 +90,7 @@ bool simConsole::sendActorMessage(std::string endpoint, std::string command, std
   if(!submitRequest(std::vector<std::string>{os.str(),command},r))
     return false;
 
-  auto rj=nlohmann::json::parse(r);
+  auto rj=Json::parse(r);
   if(rj.count("Result") || rj["Result"].is_string()){
     res=rj["Result"];
     lastErr.clear();
@@ -111,9 +111,9 @@ bool simConsole::listEndpoints(std::string tag, std::vector<std::string> &res){
   if(!submitRequest(os.str(),r))
       return false;
 
-  auto rj=nlohmann::json::parse(r);
+  auto rj=Json::parse(r);
   if(rj.count("Result") || rj["Result"].is_array()){
-    for (nlohmann::json::iterator it = rj["Result"].begin(),ec=rj["Result"].end();
+    for (Json::iterator it = rj["Result"].begin(),ec=rj["Result"].end();
          it != ec; ++it) {
       res.push_back(*it);
     }
@@ -123,7 +123,7 @@ bool simConsole::listEndpoints(std::string tag, std::vector<std::string> &res){
   lastErr="Unexpected response:"+r;
   return false;
 }
-bool simConsole::getActorMetadata(std::string actor, nlohmann::json &res){
+bool simConsole::getActorMetadata(std::string actor, Json &res){
   std::ostringstream os;
   os << "{\n"
      << "\"Type\" :  \"GetActorMeta\",\n"
@@ -133,7 +133,7 @@ bool simConsole::getActorMetadata(std::string actor, nlohmann::json &res){
   if (!submitRequest(os.str(), r))
     return false;
 
-  auto rj = nlohmann::json::parse(r);
+  auto rj = Json::parse(r);
   if (rj.count("Result")) {
     res=rj["Result"];
     lastErr.clear();

--- a/include/json.hh
+++ b/include/json.hh
@@ -1,0 +1,30 @@
+// Copyright 2018-2020 Tomoaki Yoshida <yoshida@furo.org>
+/*
+This software is released under the MIT License.
+http://opensource.org/licenses/mit-license.php
+*/
+
+#pragma once
+#include <nlohmann/json.hpp>
+
+struct ciless{
+static constexpr char lc(const char c){
+  return (c>='A' && c<='Z') ? c - ('Z' - 'z'): c;
+}
+bool operator()(const std::string&s1, const std::string&s2)const{
+  int i=0;
+  while(i<s1.size() && i<s2.size()){
+    if(lc(s1[i])<lc(s2[i])) return true;
+    if(lc(s1[i])>lc(s2[i])) return false;
+    ++i;
+  }
+  return s1.size()<s2.size();
+}
+};
+
+// case insensitive map
+template <typename K, typename V, typename C, typename A>
+using cimap=std::map<K,V,ciless, A>;
+
+// case insensitive json type
+using Json=nlohmann::basic_json<cimap>;

--- a/include/subscriber.hh
+++ b/include/subscriber.hh
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Tomoaki Yoshida<yoshida@furo.org>
+﻿// Copyright 2018-2020 Tomoaki Yoshida<yoshida@furo.org>
 /*
 This software is released under the MIT License.
 http://opensource.org/licenses/mit-license.php
@@ -12,7 +12,7 @@ http://opensource.org/licenses/mit-license.php
 #include <set>
 #include <string>
 
-#include "nlohmann/json.hpp"
+#include "json.hh"
 
 
 class simSubscriber{
@@ -24,7 +24,7 @@ public:
   bool isValid(){return Sock && Sock->isValid();}
   std::string getLastError(){return lastErr;}
   void addTargetActor(std::string actor);
-  nlohmann::json recvOne();
+  Json recvOne();
   bool waitFor(int timeout_ms);
 
 protected:
@@ -63,39 +63,39 @@ void simSubscriber::addTargetActor(std::string actor){
   Actors.insert(actor);
 }
 
-nlohmann::json simSubscriber::recvOne(){
+Json simSubscriber::recvOne(){
   zmq::message_t msg;
   auto err = Sock->recv(&msg);
   if (err < 0) {
     std::ostringstream os;
     os << " Possible reason: " << zmq_strerror(err) << std::endl;
     lastErr=os.str();
-    return nlohmann::json();
+    return Json();
   }
   lastErr.clear();
   std::string res(msg.data<char>(), msg.size());
   // 受信JSONをパース
-  nlohmann::json j = nlohmann::json::parse(res);
+  Json j = Json::parse(res);
 
   if(j.find("Report")==j.end()){
     std::ostringstream os;
     os<<"Unexpected data received(No Repot field):"<<j<<std::endl;
     lastErr=os.str();
-    return nlohmann::json();
+    return Json();
   }
   auto j2=j["Report"];
   if(j2.find("Name")==j2.end()){
     std::ostringstream os;
     os<<"Unexpected data received(No Name field):"<<j2<<std::endl;
     lastErr=os.str();
-    return nlohmann::json();
+    return Json();
   }
 
   std::string name = j2["Name"];
 
   if(Actors.size()){
     decltype(Actors)::iterator it=Actors.find(name);
-    if(it==Actors.end()) return nlohmann::json();
+    if(it==Actors.end()) return Json();
 
   }
   return j2;

--- a/srcs/simConsole.cpp
+++ b/srcs/simConsole.cpp
@@ -104,7 +104,7 @@ int main(int argc, char* argv[]) {
       std::cout<<"Result: "<<std::endl;
       for(const auto &e:res){
         std::cout<<" ["<<e<<"]"<<std::endl;
-        nlohmann::json meta;
+        Json meta;
         if(con.getActorMetadata(e,meta)){
           std::cout<<std::setw(4)<<meta<<std::endl;
         }


### PR DESCRIPTION
UEから受信するJsonのkeyをCase Insensitiveに扱う変更

UE側でJsonを扱うライブラリをCerealではなくUE組み込みのものに変更したい。しかしUEのJsonライブラリはUStructをJsonにしたときにキーの大文字小文字がUEの都合で変更され、従来のコードのままでは扱えなくなる。これに対応するためにCageClient側でキーの大文字小文字を区別せずに扱うことにする。
