### PR TITLE
Handle extended metadata and vehicle status

### DIFF
--- a/include/cageclient.hh
+++ b/include/cageclient.hh
@@ -35,6 +35,7 @@ public:
     // ground truth
     double ox, oy, oz, ow; // orientation
     double wx, wy, wz; // world position
+    double latitude, longitude;
   };
 
   struct Transform{
@@ -87,6 +88,11 @@ private:
 
   void clearError(){
     ErrorString.clear();
+  }
+
+  double decode60(std::array<double,3> v){
+    double d=v[0], m=v[1], s=v[2];
+    return ((s / 60.) + m) / 60. + d;
   }
 };
 
@@ -265,8 +271,18 @@ bool CageAPI::getStatusOne(CageAPI::vehicleStatus &vst, int timeout_us)
     vst.wy = static_cast<double>(l["Y"])/ 100. * -1.;
     vst.wz = static_cast<double>(l["Z"])/ 100.;
   }
+  auto lat=r.find("lat");
+  if(lat!=r.end()){
+    Json b = *lat;
+    vst.latitude = decode60({static_cast<double>(b["X"]), static_cast<double>(b["Y"]), static_cast<double>(b["Z"])});
+  }
+  auto lon=r.find("lon");
+  if(lon!=r.end()){
+    Json l = *lat;
+    vst.longitude = decode60({static_cast<double>(l["X"]), static_cast<double>(l["Y"]), static_cast<double>(l["Z"])});  }
   return true;
 }
+
 bool CageAPI::setRpm(double rpmL, double rpmR){
   std::ostringstream os;
   std::string res;

--- a/include/cageclient.hh
+++ b/include/cageclient.hh
@@ -10,6 +10,7 @@ http://opensource.org/licenses/mit-license.php
 #include <string>
 #include <cmath>
 #include <array>
+#include <sstream>
 
 class CageAPI{
   std::unique_ptr<zmq::context_t> ZCtx;
@@ -36,6 +37,16 @@ public:
     double ox, oy, oz, ow; // orientation
     double wx, wy, wz; // world position
     double latitude, longitude;
+    std::string toString(){
+      std::ostringstream os;
+      os << "Clock: " << simClock << "\n"
+         << "lrpm: " << lrpm << "\t rrpm: " << rrpm << "\n"
+         << "accel  x: " << ax << "\t y: " << ay << "\t z: " << az << "\n"
+         << "angvel x: " << rx << "\t y: " << ry << "\t z: " << rz << "\n"
+         <<std::setprecision(10)
+         << "latitude: "<<latitude<<"\t longitude: "<<longitude<<std::endl;
+      return os.str();
+    }
   };
 
   struct Transform{

--- a/readme.md
+++ b/readme.md
@@ -110,6 +110,17 @@ CommActorに接続し、指定したActorにコマンドを送信し、またス
   } VehicleInfo;
 ```
 
+また、シミュレータ側が対応している場合世界の緯度経度基準点の情報がWorldInfoに入ります。
+``` c++
+  struct worldInfo{
+    bool valid;
+    double Latitude0;
+    double Longitude0;
+    std::array<double, 3> ReferenceLocation;
+    std::array<double, 4> ReferenceRotation;
+  } WorldInfo;
+```
+
 ステータス受信の主要なインタフェースは次のとおりです。
 
 ``` c++
@@ -128,10 +139,13 @@ getStatusOneを呼ぶと台車の情報(CageAPI::vehicleStatus)が得られま�
     // ground truth
     double ox, oy, oz, ow; // orientation
     double wx, wy, wz; // world position
+    double latitude, longitude;
   };
 ```
 
 なお、UE4の座標系は左手系ですが、vehicleStatusには(Y軸を反転することで)右手系にしたものが入ります。
+
+latitudeとlongitudeはシミュレータ側が報告できた場合に値が入ります。
 
 ### subscriber.hh
 


### PR DESCRIPTION
1. 緯度経度でロボットの位置を受信するためのプロトコル拡張
世界の緯度経度基準点の情報をWorldInfoに格納し、ロボットの位置の緯度経度表現をVehicleStatus::latitudeとVehicleStatus::longitudeに格納する。シミュレータがこれら情報を送信してこなければWorldInfo::validをfalseとする。
特に緯度経度を扱わないのであればそのほかの挙動に変化は無い。

2. ロボット上のデバイス取り付け位置のメタデータを受信するためのプロトコル拡張
VehicleInfo::Transformsにロボット上に定義された座標系を格納する。この拡張の主な目的はLidar取り付け位置の伝達である。

CagePlugin の[b30fc47](https://github.com/furo-org/CagePlugin/commit/b30fc470f5f321d6543429e2e69ea22d348d2af5)以降を使ったシミュレータとの通信で有効となる。